### PR TITLE
Implement PaymentMethodItem Widget in Checkout UI

### DIFF
--- a/lib/features/checkout/presentation/pages/my_cart_view.dart
+++ b/lib/features/checkout/presentation/pages/my_cart_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
-import 'package:payment_getaways/core/utils/styles.dart';
+import 'package:payment_getaways/core/widgets/cutom_app_bar.dart';
 import 'package:payment_getaways/features/checkout/presentation/widgets/my_cart_view_body.dart';
 
 class MyCartView extends StatelessWidget {
@@ -9,14 +8,8 @@ class MyCartView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        leading: Center(
-            child: SvgPicture.asset('assets/images/arrow.svg', height: 20)),
-        elevation: 0,
-        backgroundColor: Colors.transparent,
-        title: const Text('My Cart',
-            textAlign: TextAlign.center, style: Styles.style25),
-        centerTitle: true,
+      appBar: buildAppBar(
+        title: 'My Cart',
       ),
       body: const CartViewBody(),
     );

--- a/lib/features/checkout/presentation/pages/payment_details_view.dart
+++ b/lib/features/checkout/presentation/pages/payment_details_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:payment_getaways/core/widgets/cutom_app_bar.dart';
+import 'package:payment_getaways/features/checkout/presentation/widgets/payment_details_view_body.dart';
+
+class PaymentDetailsView extends StatelessWidget {
+  const PaymentDetailsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: buildAppBar(
+        title: 'Payment Details',
+      ),
+      body: const PaymentDetailsViewBody(),
+    );
+  }
+}

--- a/lib/features/checkout/presentation/widgets/my_cart_view_body.dart
+++ b/lib/features/checkout/presentation/widgets/my_cart_view_body.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:payment_getaways/core/widgets/custom_button.dart';
+import 'package:payment_getaways/features/checkout/presentation/pages/payment_details_view.dart';
 import 'package:payment_getaways/features/checkout/presentation/widgets/order_info_item.dart';
 import 'package:payment_getaways/features/checkout/presentation/widgets/total_price.dart';
 
@@ -49,9 +50,9 @@ class CartViewBody extends StatelessWidget {
           CustomButton(
             text: 'Complete Payment',
             onTap: () {
-              // Navigator.of(context).push(MaterialPageRoute(builder: (context) {
-              //   return const PaymentDetailsView();
-              // }));
+              Navigator.of(context).push(MaterialPageRoute(builder: (context) {
+                return const PaymentDetailsView();
+              }));
             },
           ),
           const SizedBox(

--- a/lib/features/checkout/presentation/widgets/payment_details_view_body.dart
+++ b/lib/features/checkout/presentation/widgets/payment_details_view_body.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:payment_getaways/features/checkout/presentation/widgets/payment_method_item.dart';
+
+class PaymentDetailsViewBody extends StatelessWidget {
+  const PaymentDetailsViewBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        PaymentMethodItem(isActive: true, image: "assets/images/paypal.svg")
+      ],
+    );
+  }
+}

--- a/lib/features/checkout/presentation/widgets/payment_method_item.dart
+++ b/lib/features/checkout/presentation/widgets/payment_method_item.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+
+class PaymentMethodItem extends StatelessWidget {
+  const PaymentMethodItem({
+    super.key,
+    required this.isActive,
+    required this.image,
+  });
+
+  final bool isActive;
+  final String image;
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      width: 103,
+      height: 62,
+      decoration: ShapeDecoration(
+        shape: RoundedRectangleBorder(
+          side: BorderSide(
+            width: 1.50,
+            color: isActive ? const Color(0xFF34A853) : Colors.grey,
+          ),
+          borderRadius: BorderRadius.circular(15),
+        ),
+        shadows: [
+          BoxShadow(
+            color: isActive ? const Color(0xFF34A853) : Colors.white,
+            blurRadius: 4,
+            offset: const Offset(0, 0),
+            spreadRadius: 0,
+          )
+        ],
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(15), color: Colors.white),
+        child: Center(
+          child: SvgPicture.asset(
+            image,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:payment_getaways/app.dart';
 
+
 void main() {
   runApp(const CheckoutApp());
 }


### PR DESCRIPTION
- **Summary**: Added the `PaymentMethodItem` widget to visually represent and highlight payment methods in the checkout process.
- **Details**:
  - Created `payment_method_item.dart` under `lib/features/checkout/presentation/widgets/`.
  - The widget displays a payment method image and highlights the selected method with an animated border and shadow effect.
  - Utilizes `flutter_svg` to render SVG images for the payment method icons.
  - Customizable via the `isActive` flag to indicate the currently selected payment method.
- **Checklist**:
  - [x] Created `PaymentMethodItem` widget.
  - [x] Integrated SVG support using `flutter_svg`.
  - [x] Added animation for active payment method highlighting.
